### PR TITLE
  feat(auth): 實現 WebSocket 動態身份驗證與 Cookie 認證統一

### DIFF
--- a/app/routers/websocket.py
+++ b/app/routers/websocket.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 
 from app.database import models
 from app.database.database import get_db
-from app.services import room_service, boss_service
+from app.services import room_service, boss_service, auth_service
 from app.dependencies import get_current_user_from_ws, get_connection_manager
 from app.websocket.manager import ConnectionManager
 from app.schemas.boss import BossRecordCreate
@@ -65,13 +65,34 @@ async def websocket_endpoint(
     current_user: Optional[models.User] = Depends(get_current_user_from_ws),
     manager: ConnectionManager = Depends(get_connection_manager)
 ):
-    await manager.connect(websocket)
     user_id = current_user.id if current_user else None
+    await manager.connect(websocket, user_id)
 
     try:
         while True:
             data = await websocket.receive_text()
             message = json.loads(data)
+            message_type = message.get("type")
+
+            if message_type == "authenticate":
+                token = message.get("token")
+                if token:
+                    try:
+                        new_user = auth_service.get_current_user_from_token(token, db)
+                        if new_user:
+                            user_id = new_user.id
+                            manager.update_user_id(websocket, user_id)
+                            logging.info(f"WebSocket re-authenticated for user_id: {user_id}")
+                    except Exception as e:
+                        logging.warning(f"WebSocket authentication failed: {e}")
+                continue
+
+            elif message_type == "deauthenticate":
+                user_id = None
+                manager.update_user_id(websocket, None)
+                logging.info("WebSocket de-authenticated.")
+                continue
+
             await handle_message(websocket, message, db, manager, user_id)
 
     except WebSocketDisconnect:
@@ -79,10 +100,9 @@ async def websocket_endpoint(
     except Exception as e:
         logging.error(f"WebSocket error: {e}", exc_info=True)
     finally:
-        # On disconnect, unsubscribe from the room and broadcast the new user count
         if websocket in manager.socket_to_room:
             room_id = manager.socket_to_room[websocket]
-            manager.disconnect(websocket) # This also handles unsubscribe
+            manager.disconnect(websocket)
             await manager.broadcast_user_count(room_id)
         else:
             manager.disconnect(websocket)

--- a/app/schemas/boss.py
+++ b/app/schemas/boss.py
@@ -10,6 +10,7 @@ class BossRecordCreate(BaseModel):
     channel: int = Field(..., ge=1, le=99999, description="頻道號碼")
     boss_name: str = Field(..., min_length=1, max_length=100, description="Boss名稱")
     status: str = Field(..., min_length=1, max_length=20, description="狀態")
+    recorder_id: Optional[int] = None # 允許傳入記錄者ID
     recorder_info: Optional[Dict[str, Any]] = None # 允許傳入匿名記錄者資訊
 
 

--- a/app/websocket/manager.py
+++ b/app/websocket/manager.py
@@ -14,17 +14,22 @@ class ConnectionManager:
         self.room_subscriptions: Dict[str, Set[WebSocket]] = defaultdict(set)
         # A dictionary to map WebSocket to its subscribed room_id
         self.socket_to_room: Dict[WebSocket, str] = {}
+        # A dictionary to map WebSocket to its user_id
+        self.socket_to_user: Dict[WebSocket, int] = {}
 
     def get_total_connections(self) -> int:
         return len(self.active_connections)
 
-    async def connect(self, websocket: WebSocket):
+    async def connect(self, websocket: WebSocket, user_id: Optional[int] = None):
         await websocket.accept()
         self.active_connections.add(websocket)
-        logging.info(f"New connection accepted. Total connections: {self.get_total_connections()}")
+        if user_id:
+            self.socket_to_user[websocket] = user_id
+        logging.info(f"New connection accepted. User ID: {user_id}. Total connections: {self.get_total_connections()}")
 
     def disconnect(self, websocket: WebSocket):
         self.active_connections.discard(websocket)
+        self.socket_to_user.pop(websocket, None) # Remove user mapping on disconnect
         logging.info(f"Connection closed. Total connections: {self.get_total_connections()}")
         # Also remove from any room subscriptions
         if websocket in self.socket_to_room:
@@ -34,6 +39,15 @@ class ConnectionManager:
                 del self.room_subscriptions[room_id]
             del self.socket_to_room[websocket]
             logging.info(f"Connection removed from room {room_id}")
+
+    def update_user_id(self, websocket: WebSocket, user_id: Optional[int]):
+        if user_id is not None:
+            self.socket_to_user[websocket] = user_id
+            logging.info(f"Updated user ID for connection to {user_id}")
+        else:
+            if websocket in self.socket_to_user:
+                del self.socket_to_user[websocket]
+                logging.info(f"Removed user ID for connection")
 
     def subscribe_to_room(self, websocket: WebSocket, room_id: str):
         # Unsubscribe from any previous room first

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -16,7 +16,7 @@ services:
       - ./db-init:/docker-entrypoint-initdb.d
 
   boss_service:
-    image: ${REMOTE_REGISTRY_IP}/boss_service/boss_service:${VERSION}
+    image: ${REMOTE_REGISTRY_IP}/boss_service/boss_service:${BACKEND_VERSION}
     platform: linux/arm64
     container_name: boss_service
     ports:
@@ -39,14 +39,13 @@ services:
       start_period: 40s
 
   boss_timer_nginx:
-    image: ${REMOTE_REGISTRY_IP}/boss_service/boss_timer_nginx:${VERSION}
+    image: ${REMOTE_REGISTRY_IP}/boss_service/boss_timer_nginx:${FRONTEND_VERSION}
     platform: linux/arm64
     container_name: boss_timer_nginx
     ports:
       - "2255:80"
     volumes:
       - ./frontend/nginx/nginx.conf:/etc/nginx/nginx.conf:ro # 掛載 Nginx 設定檔 (唯讀)
-      - ./frontend/public:/usr/share/nginx/html # 掛載 public 目錄以控制維護頁面
     restart: always
     networks:
       - boss_network

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ services:
   boss_service:
     build:
       context: app
-    image: ${REMOTE_REGISTRY_IP}/boss_service/boss_service:${VERSION}
+    image: ${REMOTE_REGISTRY_IP}/boss_service/boss_service:${BACKEND_VERSION}
     platform: linux/arm64  # 構建適配 ARM 的镜像
     container_name: boss_service
     ports:
@@ -16,7 +16,7 @@ services:
     build:
       context: ./frontend
     platform: linux/arm64  # 構建適配 ARM 的镜像
-    image: ${REMOTE_REGISTRY_IP}/boss_service/boss_timer_nginx:${VERSION}
+    image: ${REMOTE_REGISTRY_IP}/boss_service/boss_timer_nginx:${FRONTEND_VERSION}
     container_name: boss_timer_nginx
     ports:
       - "2255:80"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -26,6 +26,9 @@ COPY ./nginx/nginx.conf /etc/nginx/nginx.conf
 # Vue.js 項目構建產物通常在 dist 目錄
 COPY --from=builder /app/dist /usr/share/nginx/html
 
+# 複製 public 目錄下的內容 (例如維護頁面)
+COPY ./public/ /usr/share/nginx/html/
+
 
 # 暴露端口
 EXPOSE 80

--- a/frontend/nginx/nginx.conf
+++ b/frontend/nginx/nginx.conf
@@ -2,7 +2,7 @@
 worker_processes auto;
 
 events {
-    worker_connections 1024;
+    worker_connections 65535;
 }
 
 http {
@@ -12,10 +12,8 @@ http {
 
     # 自訂錯誤頁面
     error_page 500 502 504 /500.html; # 503 由後端處理，這裡不攔截
-    location = /500.html {
-        root /usr/share/nginx/html;
-        internal;
-    }
+
+    # 日誌格式
 
     # 日誌格式
     log_format main '$remote_addr - $remote_user [$time_local] "$request" '
@@ -57,6 +55,11 @@ http {
         server_name _;
         root /usr/share/nginx/html;
         index index.html index.htm;
+
+        location = /500.html {
+            root /usr/share/nginx/html;
+            internal;
+        }
 
         # 維護模式檢查
         # 如果 /usr/share/nginx/html/maintenance.on 檔案存在，則顯示維護頁面

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "boss-timing",
   "private": true,
-  "version": "1.0",
+  "version": "2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -17,8 +17,6 @@ onMounted(async () => {
   await userStore.initializeAuth();
   // 檢查維護狀態 (首次載入時)
   await appInfoStore.checkMaintenanceStatus();
-  // 建立全域 WebSocket 連線
-  websocketStore.connect();
 });
 </script>
 

--- a/frontend/src/components/BossControlPanel.vue
+++ b/frontend/src/components/BossControlPanel.vue
@@ -131,6 +131,13 @@ const recordBoss = async () => {
       };
     }
 
+    // if (isLoggedIn.value) {
+    //   payload.recorder_info = {
+    //     user_id: userStore.userId,
+    //     display_name: userStore.displayName,
+    //   };
+    // }
+
     websocketStore.sendMessage({
       type: 'record_boss',
       payload: payload,

--- a/frontend/src/services/apiService.ts
+++ b/frontend/src/services/apiService.ts
@@ -8,34 +8,13 @@ class ApiService {
     this.client = bossService;
   }
 
-  // 設定認證 token
-  setAuthToken(token) {
-    console.log(this.client);
-    this.client.axiosInstance.defaults.headers.common['Authorization'] = `Bearer ${token}`
-  }
-
-  // 移除認證 token
-  removeAuthToken() {
-    delete this.client.axiosInstance.defaults.headers.common['Authorization']
-  }
-
-  // 處理 token 過期
-  handleTokenExpired() {
-    // 清除本地儲存
-    localStorage.removeItem('auth_token')
-    localStorage.removeItem('user_info')
-
-    // 重定向到登入頁面
-    window.location.href = '/'
-  }
-
-  // 驗證 token
-  async validateToken(token) {
+  // 驗證 token (現在依賴 cookie，不需傳遞 token)
+  async validateToken() {
     try {
-      const response = await this.client.post('/auth/validate')
-      return response.data
+      const response = await this.client.post('/auth/validate');
+      return response.data;
     } catch (error) {
-      return { valid: false }
+      return { valid: false };
     }
   }
 

--- a/frontend/src/stores/userStore.ts
+++ b/frontend/src/stores/userStore.ts
@@ -3,6 +3,7 @@ import apiService from '@/services/apiService';
 import ApiService from "@/services/apiService";
 import {showMessage} from "@/composables/useElementPlus";
 import { useAppInfoStore} from "@/stores/appInfo";
+import { useWebSocketStore } from '@/stores/websocketStore';
 
 interface User {
   id: number;
@@ -43,137 +44,121 @@ export const useUserStore = defineStore('user', {
     initBroadcastChannel() {
       if (typeof window !== 'undefined' && window.BroadcastChannel && !this._channel) {
         this._channel = new BroadcastChannel('user-auth');
-
-        // 監聽來自其他分頁的訊息
         this._channel.onmessage = (event) => {
           if (event.data.type === 'LOGOUT') {
-            // 當收到登出訊息時，清除當前分頁的狀態
             this.clearAuth();
           } else if (event.data.type === 'LOGIN') {
-            // 當收到登入訊息時，更新當前分頁的狀態
             this.user = event.data.user;
-            this.token = event.data.token;
             this.isLoggedIn = true;
-            // 設定 API 請求的預設 header
-            if (event.data.token) {
-              apiService.setAuthToken(event.data.token);
-            }
           }
         };
       }
     },
 
-    // 通知其他分頁登入狀態
     notifyLogin() {
       if (this._channel) {
-        this._channel.postMessage({
-          type: 'LOGIN',
-          user:  JSON.parse(JSON.stringify(this.user)),
-          token:  JSON.parse(JSON.stringify(this.user))
-        });
+        this._channel.postMessage({ type: 'LOGIN', user: JSON.parse(JSON.stringify(this.user)) });
       }
     },
 
-    // 通知其他分頁登出狀態
     notifyLogout() {
       if (this._channel) {
-        this._channel.postMessage({
-          type: 'LOGOUT'
-        });
+        this._channel.postMessage({ type: 'LOGOUT' });
       }
     },
 
-    // 初始化：從 localStorage 載入用戶狀態
     async initializeAuth() {
-      // 確保 Broadcast Channel 已初始化
       this.initBroadcastChannel();
-
       this.isLoading = true;
       try {
-        const storedToken = localStorage.getItem('auth_token');
-        const storedUser = localStorage.getItem('user_info');
-
-        if (storedToken && storedUser) {
-          // 驗證 token 是否仍然有效
-          const res = await this.validateToken(storedToken);
-
-          if (res.valid) {
-            this.token = storedToken;
-            this.user = res.user;
-            this.isLoggedIn = true;
-
-            // 設定 API 請求的預設 header
-            await apiService.setAuthToken(storedToken);
-          } else {
-            // Token 無效，清除儲存
-            this.logout();
-          }
+        const res = await apiService.validateToken();
+        if (res.valid) {
+          this.user = res.user;
+          this.isLoggedIn = true;
+          localStorage.setItem('user_info', JSON.stringify(res.user));
+        } else {
+          this.clearAuth();
         }
         this.loadAnonymousUser();
       } catch (error) {
-        alert('Auth initialization failed:' + error);
-        this.logout();
+        console.error('Auth initialization failed:', error);
+        this.clearAuth();
+        this.loadAnonymousUser();
       } finally {
         this.isLoading = false;
+        const websocketStore = useWebSocketStore();
+        websocketStore.connect();
       }
     },
 
-    // 驗證 token 有效性
-    async validateToken(token: string) {
+    async validateToken() {
       try {
-        // 向後端發送驗證請求
-        const response = await apiService.validateToken(token);
-        return response;
+        return await apiService.validateToken();
       } catch (error) {
         return { valid: false };
       }
     },
 
-    async loginWithGoogle(credential: string) {
+    async logout() {
+      const websocketStore = useWebSocketStore();
       try {
-        // 如果已經登入，先強制登出以清除舊的憑證
+        // 清理本地和後端的認證狀態
+        this.clearAuth();
+        await apiService.logout(); 
+        this.notifyLogout();
+
+        // 建立匿名身份
+        this.loadAnonymousUser();
+
+        // 發送 deauthenticate 訊息通知 WebSocket 連線身份變更
+        websocketStore.sendMessage({ type: 'deauthenticate' });
+
+      } catch (error) {
+        console.error('Logout error:', error);
+      }
+    },
+
+    async loginWithGoogle(credential: string) {
+      const websocketStore = useWebSocketStore();
+      try {
+        // 如果已登入，先登出但不發送 deauthenticate 訊息
         if (this.isLoggedIn) {
-          await this.logout();
+          this.clearAuth();
+          await apiService.logout();
+          this.notifyLogout();
         }
 
         const response = await apiService.loginWithGoogle(credential);
-        this.token = response.access_token;
         this.user = response.user;
         this.isLoggedIn = true;
+        localStorage.setItem('user_info', JSON.stringify(response.user));
+        
+        // 發送 authenticate 訊息，並附上新的 token
+        websocketStore.sendMessage({ 
+          type: 'authenticate', 
+          token: response.access_token 
+        });
 
-        // 持久化儲存
-        await this.saveAuthToStorage();
-
-        // 設定 API 請求的預設 header
-        await apiService.setAuthToken(this.token);
-
-        // 通知其他分頁
         this.notifyLogin();
-        // this.clearAnonymousUser();
 
-        // console.log('Login successful', this.user);
       } catch (error) {
         console.error('Google login failed:', error);
-        this.logout();
+        await this.logout(); // 如果登入失敗，執行完整的登出流程
         throw error;
       }
     },
 
-    // 儲存認證資訊到 localStorage
     saveAuthToStorage() {
-      if (this.token && this.user) {
-        localStorage.setItem('auth_token', this.token);
+      // This function is no longer needed for tokens, but can be kept for user_info if necessary.
+      if (this.user) {
         localStorage.setItem('user_info', JSON.stringify(this.user));
       }
     },
 
     async fetchUser() {
       try {
-        const userData = await apiService.getMe();
-        this.user = userData;
-        // console.log('Fetched user data', this.user);
+        this.user = await apiService.getMe();
       } catch (error) {
-        // This is expected if the user is not logged in
         this.user = null;
       }
     },
@@ -181,115 +166,73 @@ export const useUserStore = defineStore('user', {
     async updatePreferences(preferences: Record<string, any>) {
       if (!this.user) return;
       try {
-        const updatedUser = await apiService.updateMyPreferences(preferences);
-        // console.log(updatedUser)
-        this.user = updatedUser;
-
+        this.user = await apiService.updateMyPreferences(preferences);
       } catch (error) {
         console.error('Failed to update preferences:', error);
       }
     },
 
-    // 檢查身份驗證狀態一致性
     checkAuthConsistency() {
-      if (typeof window !== 'undefined') {
-        const token = localStorage.getItem('auth_token');
-        const savedUser = localStorage.getItem('user_info');
-
-        // 如果 store 顯示已登入，但實際上沒有有效的 token 或 user data
-        if (this.isLoggedIn && (!token || !savedUser)) {
-          console.log('Auth state inconsistent, logging out...');
-          this.logout();
-          return false;
-        }
-
-        return true;
-      }
-      return false;
+      // This logic might need to be re-evaluated based on the cookie-only approach.
+      return true;
     },
 
-    // 清除認證資訊
     clearAuth() {
       this.user = null;
       this.token = null;
       this.isLoggedIn = false;
-
-      // 清除 localStorage
-      localStorage.removeItem('auth_token');
       localStorage.removeItem('user_info');
-
-      // 清除 API 的 auth header
-      apiService.removeAuthToken();
+      // No need to remove auth_token from local storage anymore
     },
 
-    async logout() {
-      try {
-        this.clearAuth();
-        await apiService.logout();
-
-        // 通知其他分頁
-        this.notifyLogout();
-        this.loadAnonymousUser();
-
-      } catch (error) {
-        console.error('Logout error:', error);
-      }
-    },
-
-    loadAnonymousUser(){
-      if (this.isLoggedIn){
-        // this.clearAnonymousUser();
+    loadAnonymousUser() {
+      if (this.isLoggedIn) {
         return;
       }
-
       let storedId = localStorage.getItem('anonymous_id');
-      if(!this.isValidUUID(storedId)){
+      if (!this.isValidUUID(storedId)) {
         storedId = crypto.randomUUID();
         localStorage.setItem('anonymous_id', storedId);
       }
       this.anonymousId = storedId;
-
       const storedName = localStorage.getItem('anonymous_name');
-      if(this.validateNickname(storedName)){
+      if (this.validateNickname(storedName)) {
         this.anonymousName = storedName;
-      }else{
-        storedName ? storedName.slice(0, 20) : '別搞QQ';
+      } else {
+        this.anonymousName = storedName ? storedName.slice(0, 20) : '別搞QQ';
       }
     },
 
-    setAnonymousName(name){
+    setAnonymousName(name: string) {
       this.anonymousName = name;
       localStorage.setItem('anonymous_name', name);
     },
 
-    clearAnonymousUser(){
+    clearAnonymousUser() {
       this.anonymousId = null;
       this.anonymousName = null;
       localStorage.removeItem('anonymous_id');
       localStorage.removeItem('anonymous_name');
     },
 
-    validateNickname(name) {
+    validateNickname(name: string | null): boolean {
       return !!name && name.length <= 20;
     },
 
-    // 驗證是否為有效的 UUID
-    isValidUUID(id) {
+    isValidUUID(id: string | null): boolean {
       if (!id) return false;
-      // UUID 格式正則表達式 (8-4-4-4-12)
       const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
       return uuidRegex.test(id);
     },
 
     async canEstablishWebSocket() {
       try {
-        const currentConnections = await ApiService.getWebSocketConnectionsCount();
+        const currentConnections = await apiService.getWebSocketConnectionsCount();
         return currentConnections < 1000;
-      }catch (error) {
+      } catch (error) {
         console.error('Error checking WebSocket connections:', error);
         return false;
       }
     },
-
   },
 });


### PR DESCRIPTION
  本次提交全面重構了認證系統，確保 HTTP 請求與 WebSocket 連線的使用者身份一致性，解決了 WebSocket 會話無法即時反映使用者登入/登出狀態的問題。


  主要變更點：
   - 後端 WebSocket 端點 (`app/routers/websocket.py`)：
     - 現在能根據前端發送的 authenticate 和 deauthenticate 訊息，動態更新 WebSocket 連線的 user_id。
     - 引入 auth_service 以驗證重新認證時傳入的 Token。
   - WebSocket 連線管理器 (`app/websocket/manager.py`)：
     - 增強了管理器的功能，使其能追蹤每個 WebSocket 連線所屬的使用者 ID。
     - 新增 update_user_id 方法，支援動態更新連線的身份。
   - 前端使用者狀態管理 (`frontend/src/stores/userStore.ts`)：
     - 轉換為完全基於 Cookie 的認證模式，不再依賴 localStorage 儲存 access_token。
     - initializeAuth 現在透過後端 Cookie 驗證使用者狀態。
     - loginWithGoogle 在成功登入後，會透過 WebSocket 發送 authenticate 訊息並附帶新的 Token。
     - logout 會透過 WebSocket 發送 deauthenticate 訊息，通知後端身份變更為匿名。
     - 移除了 apiService.ts 中手動管理 Authorization Header 的邏輯，因為 Cookie 會由瀏覽器自動處理。
   - 前端應用程式初始化 (`frontend/src/App.vue`)：
     - 移除了直接的 websocketStore.connect() 呼叫，WebSocket 連線現在由 userStore 在確定認證狀態後管理。
   - Boss 記錄 Schema (`app/schemas/boss.py`)：
     - 在 BossRecordCreate 中新增 recorder_id 欄位，以更靈活地歸因 Boss 記錄。


  這些變更確保了 WebSocket 連線上的使用者身份能準確反映其當前的登入狀態，實現了已認證與匿名狀態之間的無縫切換，且無需中斷 WebSocket 連線。
