### PR TITLE
feat: 改善房間管理使用者體驗並添加次要優化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
-**/__pycache__/
+__pycache__/
 frontend/.env.development
 .env.production
 vite-key.pem

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/leaf24px.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-      <meta name="google-adsense-account" content="ca-pub-8035851123300328">
+    <meta name="google-adsense-account" content="ca-pub-8035851123300328" />
+    <meta name="description" content="楓之谷世界 artale BOSS 計時器" />
     <title>Artale BOSS Timer</title>
   </head>
   <body>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "boss-timing",
   "private": true,
-  "version": "2.2.4",
+  "version": "2.2.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -6,7 +6,7 @@
           <img src="/leaf24px.png" alt="Logo" class="h-8 w-8 mr-3">
           <h1 class=" text-2xl sm:block hidden font-bold text-white">{{ t('appHeader.title') }}</h1>
         </div>
-        <div v-if="roomId">
+        <div v-if="roomId" class="cursor-pointer" @click="copyRoomId">
           <p class="text-gray-400 text-sm">{{ t('appHeader.room') }} <span class="font-mono bg-gray-700 px-2 py-1 rounded">{{ roomId }}</span></p>
         </div>
       </div>
@@ -82,6 +82,13 @@ const handleLoginError = (error) => {
   console.error("Google sign-in error:", error);
   showMessage.error(t('appHeader.loginFailed'))
 };
+
+const copyRoomId = () => {
+  navigator.clipboard.writeText(roomId.value).then(() => {
+    showMessage.success(t('roomManager.copied'));
+  })
+}
+
 
 const handleLogout = () => {
   userStore.logout();

--- a/frontend/src/components/RoomManager.vue
+++ b/frontend/src/components/RoomManager.vue
@@ -35,6 +35,8 @@ import { useDark, useToggle } from '@vueuse/core'
 import { useUserStore } from '@/stores/userStore.js'
 import { useWebSocketStore } from '@/stores/websocketStore';
 import { useI18n } from 'vue-i18n';
+import { ElLoading } from 'element-plus';
+import {showMessage} from "@/composables/useElementPlus.js";
 
 const { t, locale } = useI18n();
 
@@ -77,15 +79,21 @@ const toggleDropdown = () => {
 
 const copyRoomId = () => {
   navigator.clipboard.writeText(roomId.value).then(() => {
-    showCopySuccess.value = true
-    setTimeout(() => {
-      showCopySuccess.value = false
-    }, 2000)
-  })
+  showMessage.success(t('roomManager.copied'))
   isDropdownOpen.value = false
+  })
 }
 
-const leaveRoom = () => {
+const leaveRoom = async () => {
+  const loadingInstance = ElLoading.service({
+    lock: true,
+    text: t('roomManager.leavingRoom'),
+    background: 'rgba(0, 0, 0, 0.7)',
+  });
+
+  // Simulate a delay to ensure the user sees the loading state
+  await new Promise(resolve => setTimeout(resolve, 500));
+
   if (roomStore.roomId) {
     websocketStore.sendMessage({
       type: 'leave_room',
@@ -93,6 +101,8 @@ const leaveRoom = () => {
     });
   }
   roomStore.clearRoomId();
-  router.push({ name: 'RoomSelection' });
+  router.push({ name: 'RoomSelection' }).finally(() => {
+    loadingInstance.close();
+  });
 };
 </script>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -36,6 +36,7 @@
     "toggleTheme": "Toggle Theme",
     "recordHistory": "Record History",
     "leaveRoom": "Leave Room",
+    "leavingRoom": "Leaving room...",
     "copied": "Copied!"
   },
   "appHeader": {

--- a/frontend/src/locales/zh.json
+++ b/frontend/src/locales/zh.json
@@ -36,6 +36,7 @@
     "toggleTheme": "切換主題",
     "recordHistory": "擊殺紀錄",
     "leaveRoom": "離開房間",
+    "leavingRoom": "正在離開房間...",
     "copied": "已複製！"
   },
   "appHeader": {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -13,6 +13,8 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  --el-color-primary: theme('colors.gray.300');
 }
 
 a {


### PR DESCRIPTION
此次提交為前端帶來了幾項改進，並清理了 gitignore 檔案。

- **複製房間 ID**: 使用者現在可以點擊標頭中的房間 ID，將其複製到剪貼簿。
- **離開房間載入狀態**: 當使用者離開房間時，會顯示一個載入指示器，提供更好的視覺回饋。
- **SEO 優化**: 為 `index.html` 添加了 meta 描述，以提高搜尋引擎可見性。
- **UI 主題化**: 調整了 Element Plus 組件的主色。
- **Gitignore**: 簡化了 `.gitignore` 檔案中的 `__pycache__` 規則。