### PR TITLE
refactor(auth): extract GoogleLoginButton into reusable component

### DIFF
--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -28,6 +28,7 @@ declare module 'vue' {
     ElOption: typeof import('element-plus/es')['ElOption']
     ElSelect: typeof import('element-plus/es')['ElSelect']
     ElSwitch: typeof import('element-plus/es')['ElSwitch']
+    GoogleLoginButton: typeof import('./src/components/GoogleLoginButton.vue')['default']
     MaintenanceBanner: typeof import('./src/components/MaintenanceBanner.vue')['default']
     RecommendedChannels: typeof import('./src/components/RecommendedChannels.vue')['default']
     RecommendedSection: typeof import('./src/components/RecommendedSection.vue')['default']

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -25,12 +25,10 @@
         </div>
 
         <!-- Auth Section -->
-        <div v-if="!isLoggedIn" class="dark:p-[1px] dark:rounded-[4px] dark:border border-gray-600 flex items-center min-h-[40px]">
-          <GoogleLogin
-            v-if="showGoogleButton"
+        <div v-if="!isLoggedIn" class="flex items-center min-h-[40px]">
+          <GoogleLoginButton
             :callback="handleLoginSuccess"
             :error="handleLoginError"
-            :buttonConfig="googleButtonConfig"
           />
         </div>
         <div v-else class="flex items-center space-x-3">
@@ -51,7 +49,7 @@ import { useRoomStore } from '@/stores/roomStore'
 import { useUserStore } from '@/stores/userStore'
 import { UsersIcon } from '@heroicons/vue/24/outline'
 import RoomManager from '@/components/RoomManager.vue'
-import { GoogleLogin } from "vue3-google-login"
+import GoogleLoginButton from "@/components/GoogleLoginButton.vue"
 import { showMessage } from "@/composables/useElementPlus"
 import { useI18n } from "vue-i18n"
 import { computed, ref, watch, nextTick, onMounted } from 'vue'
@@ -59,25 +57,7 @@ import { isDark } from '@/composables/useTheme'
 
 const { t } = useI18n()
 
-// Initialize as false to prevent rendering before theme is ready (avoids white flash in prod)
-const showGoogleButton = ref(false)
 
-const googleButtonConfig = computed(() => ({
-  type: 'standard',
-  size: 'medium',
-  theme: isDark.value ? 'filled_black' : 'outline',
-}))
-
-watch(isDark, async () => {
-  // 1. Remove button to force re-render with new theme config
-  showGoogleButton.value = false
-
-  // 2. Wait for DOM update
-  await nextTick()
-
-  // 3. Add button back
-  showGoogleButton.value = true
-})
 
 const roomStore = useRoomStore()
 const { roomId, isConnected, userCount } = storeToRefs(roomStore)
@@ -106,11 +86,5 @@ const copyRoomId = () => {
   })
 }
 
-onMounted(() => {
-  // Delay showing the button slightly to ensure 'isDark' and hydration are settled
-  // This helps avoid the case where isDark is undefined/false initially in prod
-  nextTick(() => {
-     showGoogleButton.value = true
-  })
-})
+
 </script>

--- a/frontend/src/components/GoogleLoginButton.vue
+++ b/frontend/src/components/GoogleLoginButton.vue
@@ -1,0 +1,38 @@
+<template>
+  <GoogleLogin :callback="callback" :error="error">
+    <el-button
+      type="primary"
+      plain
+      class="flex items-center justify-center gap-2 !h-8 !px-4 !border-gray-300 dark:!border-gray-600 !bg-white dark:!bg-gray-800 !text-gray-600 dark:!text-gray-400 hover:!bg-gray-50 dark:hover:!bg-gray-700 shadow-sm"
+    >
+      <svg class="w-4 h-4" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4" />
+        <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
+        <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
+        <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
+      </svg>
+
+      <span class="text-sm font-medium">
+        {{ t('login.google') }}
+      </span>
+    </el-button>
+  </GoogleLogin>
+</template>
+
+<script setup>
+import { GoogleLogin } from "vue3-google-login";
+import { useI18n } from 'vue-i18n';
+
+const { t } = useI18n();
+
+defineProps({
+  callback: {
+    type: Function,
+    required: true,
+  },
+  error: {
+    type: Function,
+    default: () => {},
+  },
+});
+</script>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1,4 +1,7 @@
 {
+  "login": {
+    "google": "Sign in with Google"
+  },
   "roomSelection": {
     "title": "Artale BOSS Timer",
     "subtitle": "Real-time boss tracking for your party.",

--- a/frontend/src/locales/zh.json
+++ b/frontend/src/locales/zh.json
@@ -1,4 +1,7 @@
 {
+  "login": {
+    "google": "使用 Google 帳戶登入"
+  },
   "roomSelection": {
     "title": "Artale BOSS 計時器",
     "subtitle": "為您的團隊提供即時的BOSS追蹤。",

--- a/frontend/src/views/RoomSelection.vue
+++ b/frontend/src/views/RoomSelection.vue
@@ -63,13 +63,7 @@
           </div>
           <div class="relative"><div class="absolute inset-0 flex items-center"><div class="w-full border-t border-gray-300 dark:border-gray-700"></div></div><div class="relative flex justify-center text-sm"><span class="px-2 text-gray-500 dark:text-gray-400 bg-white dark:bg-gray-800">{{ t('roomSelection.or') }}</span></div></div>
           <p class="text-gray-600 dark:text-gray-300 text-sm">{{ t('roomSelection.loginPrompt') }}</p>
-          <GoogleLogin
-            v-if="showGoogleButton"
-            :callback="handleLoginSuccess"
-            :error="handleLoginError"
-            :buttonConfig="googleButtonConfig"
-            class="dark:dark:rounded-[4px] dark:border border-gray-600 flex items-center"
-          />
+          <GoogleLoginButton :callback="handleLoginSuccess" :error="handleLoginError" />
         </div>
         <div v-else class="flex items-center justify-center space-x-4">
           <img :src="userStore.user.avatar_url" alt="User Avatar" class="w-10 h-10 rounded-full" v-if="userStore.user && userStore.user.avatar_url"/>
@@ -91,7 +85,7 @@ import { useRoomStore } from '@/stores/roomStore';
 import { useUserStore } from '@/stores/userStore';
 import apiService from '@/services/apiService';
 import { showMessage } from "@/composables/useElementPlus.js";
-import { GoogleLogin } from "vue3-google-login";
+import GoogleLoginButton from "@/components/GoogleLoginButton.vue";
 import { useI18n } from 'vue-i18n';
 import LanguageIcon from "@/assets/icons/LanguageIcon.vue";
 import {Moon, Sunny} from "@element-plus/icons-vue";
@@ -106,25 +100,7 @@ const joinRoomId = ref('');
 const joinRoomError = ref('');
 const isCreating = ref(false);
 const isJoining = ref(false);
-const showGoogleButton = ref(true);
 
-const googleButtonConfig = computed(() => ({
-  type: 'standard',
-  size: 'medium',
-  theme: isDark.value ? 'filled_black' : 'outline',
-}));
-
-
-watch(isDark, async () => {
-  // 1. 先把按鈕移除 (銷毀 DOM)
-  showGoogleButton.value = false;
-
-  // 2. 等待 Vue 完成 DOM 更新 (這時候按鈕是真的消失了)
-  await nextTick();
-
-  // 3. 再次把按鈕加回來 (這時候會讀取最新的 googleButtonConfig 並重新向 Google 請求 iframe)
-  showGoogleButton.value = true;
-});
 
 
 const switchLanguage = () => {


### PR DESCRIPTION
- Create GoogleLoginButton.vue utilizing `el-button` for consistent styling with RoomManager
- Refactor RoomSelection.vue to use the new reusable component
- Update AppHeader.vue to replace the default Google button with the new component
- Add `login.google` translation keys to en.json and `zh.json`
- Ensure dark mode and layout consistency across the application
Extracted the Google Login logic and styling into a dedicated GoogleLoginButton.vue component. This change unifies the appearance of the login button in `RoomSelection` and `AppHeader`, ensuring it matches the style of `RoomManager` (using `el-button` with identical classes) and supports dark mode correctly.